### PR TITLE
Buscar diaristas por CEP

### DIFF
--- a/Api/Diaristas/Controllers/DiaristaController.cs
+++ b/Api/Diaristas/Controllers/DiaristaController.cs
@@ -1,0 +1,21 @@
+using EDiaristas.Api.Diaristas.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EDiaristas.Api.Diaristas.Controllers;
+
+[ApiController]
+public class DiaristaController : ControllerBase
+{
+    private readonly IDiaristaService _diaristaService;
+
+    public DiaristaController(IDiaristaService diaristaService)
+    {
+        _diaristaService = diaristaService;
+    }
+
+    [HttpGet("api/diaristas/localidades")]
+    public IActionResult FindByCep(string cep)
+    {
+        return Ok(_diaristaService.FindByCep(cep));
+    }
+}

--- a/Api/Diaristas/Controllers/DiaristaController.cs
+++ b/Api/Diaristas/Controllers/DiaristaController.cs
@@ -1,4 +1,5 @@
 using EDiaristas.Api.Diaristas.Services;
+using EDiaristas.Api.Diaristas.Routes;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EDiaristas.Api.Diaristas.Controllers;
@@ -13,7 +14,7 @@ public class DiaristaController : ControllerBase
         _diaristaService = diaristaService;
     }
 
-    [HttpGet("api/diaristas/localidades")]
+    [HttpGet(DiaristaRoutes.BuscarDiaristasPorCep)]
     public IActionResult FindByCep(string cep)
     {
         return Ok(_diaristaService.FindByCep(cep));

--- a/Api/Diaristas/Dtos/DiaristaLocalidadePagedResponse.cs
+++ b/Api/Diaristas/Dtos/DiaristaLocalidadePagedResponse.cs
@@ -1,0 +1,16 @@
+namespace EDiaristas.Api.Diaristas.Dtos;
+
+public class DiaristaLocalidadePagedResponse
+{
+    public ICollection<DiaristaLocalidadeResponse> Diaristas { get; set; }
+    public int QunatidadeDiaristas { get; set; }
+
+    public DiaristaLocalidadePagedResponse(
+        ICollection<DiaristaLocalidadeResponse> diaristas,
+        int tamanhoPagina,
+        int totalElementos)
+    {
+        Diaristas = diaristas;
+        QunatidadeDiaristas = totalElementos > tamanhoPagina ? totalElementos - tamanhoPagina : 0;
+    }
+}

--- a/Api/Diaristas/Dtos/DiaristaLocalidadeResponse.cs
+++ b/Api/Diaristas/Dtos/DiaristaLocalidadeResponse.cs
@@ -1,0 +1,10 @@
+namespace EDiaristas.Api.Diaristas.Dtos;
+
+public class DiaristaLocalidadeResponse
+{
+    public int Id { get; set; }
+    public string NomeCompleto { get; set; } = string.Empty;
+    public double Reputacao { get; set; }
+    public string FotoUsuario { get; set; } = string.Empty;
+    public string Cidade { get; set; } = string.Empty;
+}

--- a/Api/Diaristas/Mappers/DiaristaMapper.cs
+++ b/Api/Diaristas/Mappers/DiaristaMapper.cs
@@ -1,0 +1,19 @@
+using EDiaristas.Api.Diaristas.Dtos;
+using EDiaristas.Core.Models;
+
+namespace EDiaristas.Api.Diaristas.Mappers;
+
+public class DiaristaMapper : IDiaristaMapper
+{
+    public DiaristaLocalidadeResponse ToLocalidadeResponse(Usuario usuario)
+    {
+        return new DiaristaLocalidadeResponse
+        {
+            Id = usuario.Id,
+            NomeCompleto = usuario.NomeCompleto,
+            Reputacao = usuario.Reputacao ?? 0,
+            FotoUsuario = "",
+            Cidade = ""
+        };
+    }
+}

--- a/Api/Diaristas/Mappers/IDiaristaMapper.cs
+++ b/Api/Diaristas/Mappers/IDiaristaMapper.cs
@@ -1,0 +1,9 @@
+using EDiaristas.Api.Diaristas.Dtos;
+using EDiaristas.Core.Models;
+
+namespace EDiaristas.Api.Diaristas.Mappers;
+
+public interface IDiaristaMapper
+{
+    DiaristaLocalidadeResponse ToLocalidadeResponse(Usuario usuario);
+}

--- a/Api/Diaristas/Routes/DiaristaRoutes.cs
+++ b/Api/Diaristas/Routes/DiaristaRoutes.cs
@@ -1,0 +1,6 @@
+namespace EDiaristas.Api.Diaristas.Routes;
+
+public static class DiaristaRoutes
+{
+    public const string BuscarDiaristasPorCep = "api/diaristas/localidades";
+}

--- a/Api/Diaristas/Services/DiaristaService.cs
+++ b/Api/Diaristas/Services/DiaristaService.cs
@@ -1,0 +1,35 @@
+using EDiaristas.Api.Diaristas.Dtos;
+using EDiaristas.Api.Diaristas.Mappers;
+using EDiaristas.Core.Repositories;
+using EDiaristas.Core.Repositories.Usuarios;
+using EDiaristas.Core.Services.ConsultaEndereco.Adapters;
+
+namespace EDiaristas.Api.Diaristas.Services;
+
+public class DiaristaService : IDiaristaService
+{
+    private readonly IDiaristaMapper _diaristaMapper;
+    private readonly IUsuarioRepository _usuarioRepository;
+    private readonly IConsultaEnderecoService _consultaEnderecoService;
+
+    public DiaristaService(
+        IDiaristaMapper diaristaMapper,
+        IUsuarioRepository usuarioRepository,
+        IConsultaEnderecoService consultaEnderecoService)
+    {
+        _diaristaMapper = diaristaMapper;
+        _usuarioRepository = usuarioRepository;
+        _consultaEnderecoService = consultaEnderecoService;
+    }
+
+    public DiaristaLocalidadePagedResponse FindByCep(string cep)
+    {
+        var codigoIbge = _consultaEnderecoService.FindEnderecoByCep(cep).Ibge;
+        var result = _usuarioRepository.FindByCidadesAtentidasCodigoIbge(codigoIbge, new PagedFilter(1, 6));
+        return new DiaristaLocalidadePagedResponse(
+            result.Elements.Select(_diaristaMapper.ToLocalidadeResponse).ToList(),
+            result.PageSize,
+            result.TotalElements
+        );
+    }
+}

--- a/Api/Diaristas/Services/IDiaristaService.cs
+++ b/Api/Diaristas/Services/IDiaristaService.cs
@@ -1,0 +1,8 @@
+using EDiaristas.Api.Diaristas.Dtos;
+
+namespace EDiaristas.Api.Diaristas.Services;
+
+public interface IDiaristaService
+{
+    DiaristaLocalidadePagedResponse FindByCep(string cep);
+}

--- a/Api/Endereco/Controllers/EnderecoController.cs
+++ b/Api/Endereco/Controllers/EnderecoController.cs
@@ -1,0 +1,22 @@
+using EDiaristas.Core.Services.ConsultaEndereco.Adapters;
+using EDiaristas.Api.Enderecos.Routes;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EDiaristas.Api.Enderecos.Controllers;
+
+[ApiController]
+public class EnderecoController : ControllerBase
+{
+    private readonly IConsultaEnderecoService _consultaEnderecoService;
+
+    public EnderecoController(IConsultaEnderecoService consultaEnderecoService)
+    {
+        _consultaEnderecoService = consultaEnderecoService;
+    }
+
+    [HttpGet(EnderecoRoutes.BuscarEnderecoPorCep)]
+    public IActionResult BuscarEnderecoPorCep(string cep)
+    {
+        return Ok(_consultaEnderecoService.FindEnderecoByCep(cep));
+    }
+}

--- a/Api/Endereco/Routes/EnderecoRoutes.cs
+++ b/Api/Endereco/Routes/EnderecoRoutes.cs
@@ -1,0 +1,6 @@
+namespace EDiaristas.Api.Enderecos.Routes;
+
+public static class EnderecoRoutes
+{
+    public const string BuscarEnderecoPorCep = "/api/enderecos";
+}

--- a/Config/Api/ApiMappersConfig.cs
+++ b/Config/Api/ApiMappersConfig.cs
@@ -1,3 +1,4 @@
+using EDiaristas.Api.Diaristas.Mappers;
 using EDiaristas.Api.Servicos.Mappers;
 
 namespace EDiaristas.Config.Api;
@@ -7,5 +8,6 @@ public static class ApiMappersConfig
     public static void RegisterApiMappers(this IServiceCollection services)
     {
         services.AddScoped<IServicoMapper, ServicoMapper>();
+        services.AddScoped<IDiaristaMapper, DiaristaMapper>();
     }
 }

--- a/Config/Api/ApiServicesConfig.cs
+++ b/Config/Api/ApiServicesConfig.cs
@@ -1,3 +1,4 @@
+using EDiaristas.Api.Diaristas.Services;
 using EDiaristas.Api.Servicos.Services;
 
 namespace EDiaristas.Config.Api;
@@ -7,5 +8,6 @@ public static class ApiServicesConfig
     public static void RegisterApiServices(this IServiceCollection services)
     {
         services.AddScoped<IServicoService, ServicoService>();
+        services.AddScoped<IDiaristaService, DiaristaService>();
     }
 }

--- a/Config/Core/CoreServicesConfig.cs
+++ b/Config/Core/CoreServicesConfig.cs
@@ -1,0 +1,13 @@
+using EDiaristas.Core.Services.ConsultaEndereco.Adapters;
+using EDiaristas.Core.Services.ConsultaEndereco.Providers;
+
+namespace EDiaristas.Config.Core;
+
+public static class CoreServicesConfig
+{
+    public static void RegisterCoreServices(this IServiceCollection services)
+    {
+        services.AddScoped<IConsultaEnderecoService, ViaCepService>();
+        services.AddSingleton<HttpClient>();
+    }
+}

--- a/Config/ServicesConfig.cs
+++ b/Config/ServicesConfig.cs
@@ -1,5 +1,6 @@
 using EDiaristas.Config.Admin;
 using EDiaristas.Config.Api;
+using EDiaristas.Config.Core;
 
 namespace EDiaristas.Config;
 
@@ -7,7 +8,9 @@ public static class ServicesConfig
 {
     public static void RegisterServices(this IServiceCollection services)
     {
-        services.RegisterAdminServices();
         services.RegisterApiServices();
+        services.RegisterCoreServices();
+        services.RegisterAdminServices();
+
     }
 }

--- a/Core/Data/Contexts/EDiaristasDbContext.cs
+++ b/Core/Data/Contexts/EDiaristasDbContext.cs
@@ -20,5 +20,6 @@ public class EDiaristasDbContext : IdentityDbContext<Usuario, IdentityRole<int>,
         base.OnModelCreating(builder);
         builder.ApplyConfiguration(new ServicoEntityConfig());
         builder.ApplyConfiguration(new UsuarioEntityConfig());
+        builder.ApplyConfiguration(new CidadeAtendidaEntityConfig());
     }
 }

--- a/Core/Data/EntityConfigs/CidadeAtendidaEntityConfig.cs
+++ b/Core/Data/EntityConfigs/CidadeAtendidaEntityConfig.cs
@@ -1,0 +1,30 @@
+using EDiaristas.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EDiaristas.Core.Data.EntityConfigs;
+
+public class CidadeAtendidaEntityConfig : IEntityTypeConfiguration<CidadeAtendida>
+{
+    public void Configure(EntityTypeBuilder<CidadeAtendida> builder)
+    {
+        builder.ToTable("CidadeAtendida");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.CodigoIbge)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(c => c.Cidade)
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.Property(c => c.Estado)
+            .HasMaxLength(2)
+            .IsRequired();
+
+        builder.HasMany(c => c.Usuarios)
+            .WithMany(u => u.CidadesAtendidas);
+    }
+}

--- a/Core/Data/EntityConfigs/UsuarioEntityConfig.cs
+++ b/Core/Data/EntityConfigs/UsuarioEntityConfig.cs
@@ -11,5 +11,20 @@ public class UsuarioEntityConfig : IEntityTypeConfiguration<Usuario>
         builder.Property(u => u.NomeCompleto)
             .HasMaxLength(100)
             .IsRequired();
+
+        builder.Property(u => u.Cpf)
+            .HasMaxLength(11)
+            .IsRequired(false);
+
+        builder.Property(u => u.Nascimento)
+            .IsRequired(false);
+
+        builder.Property(u => u.Reputacao)
+            .HasPrecision(2, 1)
+            .IsRequired(false);
+
+        builder.Property(u => u.ChavePix)
+            .HasMaxLength(255)
+            .IsRequired(false);
     }
 }

--- a/Core/Data/Migrations/20220707013642_UpdateUserTable.Designer.cs
+++ b/Core/Data/Migrations/20220707013642_UpdateUserTable.Designer.cs
@@ -4,6 +4,7 @@ using EDiaristas.Core.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EDiaristas.Core.Data.Migrations
 {
     [DbContext(typeof(EDiaristasDbContext))]
-    partial class EDiaristasDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220707013642_UpdateUserTable")]
+    partial class UpdateUserTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Core/Data/Migrations/20220707013642_UpdateUserTable.cs
+++ b/Core/Data/Migrations/20220707013642_UpdateUserTable.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EDiaristas.Core.Data.Migrations
+{
+    public partial class UpdateUserTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ChavePix",
+                table: "AspNetUsers",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Cpf",
+                table: "AspNetUsers",
+                type: "nvarchar(11)",
+                maxLength: 11,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Nascimento",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Reputacao",
+                table: "AspNetUsers",
+                type: "float(2)",
+                precision: 2,
+                scale: 1,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChavePix",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Cpf",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Nascimento",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Reputacao",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Core/Data/Migrations/20220707014451_CreateCidadeAtendidaTable.Designer.cs
+++ b/Core/Data/Migrations/20220707014451_CreateCidadeAtendidaTable.Designer.cs
@@ -4,6 +4,7 @@ using EDiaristas.Core.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EDiaristas.Core.Data.Migrations
 {
     [DbContext(typeof(EDiaristasDbContext))]
-    partial class EDiaristasDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220707014451_CreateCidadeAtendidaTable")]
+    partial class CreateCidadeAtendidaTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Core/Data/Migrations/20220707014451_CreateCidadeAtendidaTable.cs
+++ b/Core/Data/Migrations/20220707014451_CreateCidadeAtendidaTable.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EDiaristas.Core.Data.Migrations
+{
+    public partial class CreateCidadeAtendidaTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CidadeAtendida",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CodigoIbge = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Cidade = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    Estado = table.Column<string>(type: "nvarchar(2)", maxLength: 2, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CidadeAtendida", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CidadeAtendidaUsuario",
+                columns: table => new
+                {
+                    CidadesAtendidasId = table.Column<int>(type: "int", nullable: false),
+                    UsuariosId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CidadeAtendidaUsuario", x => new { x.CidadesAtendidasId, x.UsuariosId });
+                    table.ForeignKey(
+                        name: "FK_CidadeAtendidaUsuario_AspNetUsers_UsuariosId",
+                        column: x => x.UsuariosId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CidadeAtendidaUsuario_CidadeAtendida_CidadesAtendidasId",
+                        column: x => x.CidadesAtendidasId,
+                        principalTable: "CidadeAtendida",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CidadeAtendidaUsuario_UsuariosId",
+                table: "CidadeAtendidaUsuario",
+                column: "UsuariosId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CidadeAtendidaUsuario");
+
+            migrationBuilder.DropTable(
+                name: "CidadeAtendida");
+        }
+    }
+}

--- a/Core/Models/CidadeAtendida.cs
+++ b/Core/Models/CidadeAtendida.cs
@@ -1,0 +1,11 @@
+namespace EDiaristas.Core.Models;
+
+public class CidadeAtendida
+{
+    public int Id { get; set; }
+    public string CodigoIbge { get; set; } = string.Empty;
+    public string Cidade { get; set; } = string.Empty;
+    public string Estado { get; set; } = string.Empty;
+
+    public ICollection<Usuario>? Usuarios { get; set; }
+}

--- a/Core/Models/Usuario.cs
+++ b/Core/Models/Usuario.cs
@@ -9,4 +9,6 @@ public class Usuario : IdentityUser<int>
     public DateTime? Nascimento { get; set; }
     public double? Reputacao { get; set; }
     public string? ChavePix { get; set; }
+
+    public ICollection<CidadeAtendida>? CidadesAtendidas { get; set; }
 }

--- a/Core/Models/Usuario.cs
+++ b/Core/Models/Usuario.cs
@@ -5,4 +5,8 @@ namespace EDiaristas.Core.Models;
 public class Usuario : IdentityUser<int>
 {
     public string NomeCompleto { get; set; } = string.Empty;
+    public string? Cpf { get; set; }
+    public DateTime? Nascimento { get; set; }
+    public double? Reputacao { get; set; }
+    public string? ChavePix { get; set; }
 }

--- a/Core/Models/Usuario.cs
+++ b/Core/Models/Usuario.cs
@@ -10,5 +10,5 @@ public class Usuario : IdentityUser<int>
     public double? Reputacao { get; set; }
     public string? ChavePix { get; set; }
 
-    public ICollection<CidadeAtendida>? CidadesAtendidas { get; set; }
+    public ICollection<CidadeAtendida> CidadesAtendidas { get; set; } = new List<CidadeAtendida>();
 }

--- a/Core/Repositories/PagedFilter.cs
+++ b/Core/Repositories/PagedFilter.cs
@@ -1,0 +1,13 @@
+namespace EDiaristas.Core.Repositories;
+
+public class PagedFilter
+{
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+
+    public PagedFilter(int page, int pageSize)
+    {
+        Page = page > 0 ? page : 1;
+        PageSize = pageSize > 0 ? pageSize : 10;
+    }
+}

--- a/Core/Repositories/PagedResult.cs
+++ b/Core/Repositories/PagedResult.cs
@@ -1,0 +1,8 @@
+namespace EDiaristas.Core.Repositories;
+
+public class PagedResult<Model>
+{
+    public ICollection<Model> Elements { get; set; } = new List<Model>();
+    public int PageSize { get; set; }
+    public int TotalElements { get; set; }
+}

--- a/Core/Repositories/Usuarios/IUsuarioRepository.cs
+++ b/Core/Repositories/Usuarios/IUsuarioRepository.cs
@@ -10,4 +10,5 @@ public interface IUsuarioRepository : ICrudRepository<Usuario, int>
     void UpdatePassword(string email, string oldPassword, string newPassword);
     bool CheckPassword(string email, string password);
     void AddRole(string email, string role);
+    PagedResult<Usuario> FindByCidadesAtentidasCodigoIbge(string codigoIbge, PagedFilter filter);
 }

--- a/Core/Repositories/Usuarios/UsuarioRepository.cs
+++ b/Core/Repositories/Usuarios/UsuarioRepository.cs
@@ -76,6 +76,24 @@ public class UsuarioRepository : IUsuarioRepository
         return _userManager.Users.AsNoTracking().ToList();
     }
 
+    public PagedResult<Usuario> FindByCidadesAtentidasCodigoIbge(string codigoIbge, PagedFilter filter)
+    {
+        var query = _userManager.Users.AsNoTracking()
+            .Include(x => x.CidadesAtendidas)
+            .Where(x => x.CidadesAtendidas.Any(c => c.CodigoIbge == codigoIbge));
+        var usuarios = query.Skip((filter.Page - 1) * filter.PageSize)
+            .Take(filter.PageSize)
+            .OrderBy(x => x.Reputacao)
+            .ToList();
+        var count = query.Count();
+        return new PagedResult<Usuario>
+        {
+            Elements = usuarios,
+            PageSize = filter.PageSize,
+            TotalElements = count
+        };
+    }
+
     public Usuario? FindByEmail(string email)
     {
         return _userManager.Users.AsNoTracking().FirstOrDefault(u => u.Email == email);

--- a/Core/Services/ConsultaEndereco/Adapters/IConsultaEnderecoService.cs
+++ b/Core/Services/ConsultaEndereco/Adapters/IConsultaEnderecoService.cs
@@ -1,0 +1,8 @@
+using EDiaristas.Core.Services.ConsultaEndereco.Dtos;
+
+namespace EDiaristas.Core.Services.ConsultaEndereco.Adapters;
+
+public interface IConsultaEnderecoService
+{
+    EnderecoResponse FindEnderecoByCep(string cep);
+}

--- a/Core/Services/ConsultaEndereco/Dtos/EnderecoResponse.cs
+++ b/Core/Services/ConsultaEndereco/Dtos/EnderecoResponse.cs
@@ -1,0 +1,12 @@
+namespace EDiaristas.Core.Services.ConsultaEndereco.Dtos;
+
+public class EnderecoResponse
+{
+    public string Cep { get; set; } = string.Empty;
+    public string Logradouro { get; set; } = string.Empty;
+    public string Complemento { get; set; } = string.Empty;
+    public string Bairro { get; set; } = string.Empty;
+    public string Localidade { get; set; } = string.Empty;
+    public string Uf { get; set; } = string.Empty;
+    public string Ibge { get; set; } = string.Empty;
+}

--- a/Core/Services/ConsultaEndereco/Exceptions/CepNotFoundException.cs
+++ b/Core/Services/ConsultaEndereco/Exceptions/CepNotFoundException.cs
@@ -1,0 +1,7 @@
+namespace EDiaristas.Core.Services.ConsultaEndereco.Exceptions;
+
+public class CepNotFoundException : ConsultaEnderecoServiceException
+{
+    public CepNotFoundException(string message = "O CEP informado não foi encontrado") : base(message)
+    { }
+}

--- a/Core/Services/ConsultaEndereco/Exceptions/ConsultaEnderecoServiceException.cs
+++ b/Core/Services/ConsultaEndereco/Exceptions/ConsultaEnderecoServiceException.cs
@@ -1,0 +1,7 @@
+namespace EDiaristas.Core.Services.ConsultaEndereco.Exceptions;
+
+public class ConsultaEnderecoServiceException : Exception
+{
+    public ConsultaEnderecoServiceException(string message) : base(message)
+    { }
+}

--- a/Core/Services/ConsultaEndereco/Exceptions/InvalidCepException.cs
+++ b/Core/Services/ConsultaEndereco/Exceptions/InvalidCepException.cs
@@ -1,0 +1,7 @@
+namespace EDiaristas.Core.Services.ConsultaEndereco.Exceptions;
+
+public class InvalidCepException : ConsultaEnderecoServiceException
+{
+    public InvalidCepException(string message = "O CEP informado é inválido") : base(message)
+    { }
+}

--- a/Core/Services/ConsultaEndereco/Providers/ViaCepService.cs
+++ b/Core/Services/ConsultaEndereco/Providers/ViaCepService.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using EDiaristas.Core.Services.ConsultaEndereco.Adapters;
+using EDiaristas.Core.Services.ConsultaEndereco.Dtos;
+using EDiaristas.Core.Services.ConsultaEndereco.Exceptions;
+
+namespace EDiaristas.Core.Services.ConsultaEndereco.Providers;
+
+public class ViaCepService : IConsultaEnderecoService
+{
+    private const string Url = "https://viacep.com.br/ws/{0}/json/";
+    private readonly HttpClient _httpClient;
+
+    public ViaCepService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public EnderecoResponse FindEnderecoByCep(string cep)
+    {
+        var url = string.Format(Url, cep);
+        var response = _httpClient.GetAsync(url).Result;
+        if (response.IsSuccessStatusCode)
+        {
+            var json = response.Content.ReadAsStringAsync().Result;
+            var endereco = JsonSerializer.Deserialize<EnderecoResponse>(
+                json,
+                new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
+            ) ?? new EnderecoResponse();
+            if (string.IsNullOrWhiteSpace(endereco.Logradouro))
+            {
+                throw new CepNotFoundException();
+            }
+            return endereco;
+        }
+        throw new InvalidCepException();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Na primeira execução do projeto é criado o usuário inicial que possui as seg
 
 ## Rotas da API
 
-| Verbo | Rota         | Funcionalidade              | Requer Autenticação? |
-| ----- | ------------ | --------------------------- | -------------------- |
-| GET   | api/servicos | Listar serviços cadastrados | Não                  |
+| Verbo | Rota                      | Funcionalidade                                  | Requer Autenticação? |
+| ----- | ------------------------- | ----------------------------------------------- | -------------------- |
+| GET   | api/servicos              | Listar serviços cadastrados                     | Não                  |
+| GET   | api/diaristas/localidades | Listar diaristas que atendem um determinado cep | Não                  |
+| GET   | /api/enderecos            | Buscar endereço por cep                         | Não                  |
 
 ## TODO
 
@@ -72,8 +74,9 @@ Na primeira execução do projeto é criado o usuário inicial que possui as seg
   - [x] Logout
   - [x] Alteração de senha
   - [ ] Reset de senha
-- [ ] Buscar diaristas que atendem um cep
+- [x] Buscar diaristas que atendem um cep
   - [x] Listar diaristas que atendem um cep
+  - [x] Buscar endereço por cep
 - [ ] Contratação de Diarista (Detalhes do Serviço)
   - [ ] Verificação de disponibilidade por CEP
   - [ ] Busca de endereço por CEP

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Na primeira execução do projeto é criado o usuário inicial que possui as seg
   - [x] Alteração de senha
   - [ ] Reset de senha
 - [ ] Buscar diaristas que atendem um cep
+  - [x] Listar diaristas que atendem um cep
 - [ ] Contratação de Diarista (Detalhes do Serviço)
   - [ ] Verificação de disponibilidade por CEP
   - [ ] Busca de endereço por CEP


### PR DESCRIPTION
Foram implementadas duas novas rotas, uma de busca de diaristas por cep e uma de busca de endereço por cep.

| Verbo | Rota                      | Funcionalidade                                  | Requer Autenticação? |
| ----- | ------------------------- | ----------------------------------------------- | -------------------- |
| GET   | api/diaristas/localidades | Listar diaristas que atendem um determinado cep | Não                  |
| GET   | /api/enderecos            | Buscar endereço por cep                         | Não                  |